### PR TITLE
Fix typo preventing app from starting

### DIFF
--- a/riot_webpack/src/store/blogstore.js
+++ b/riot_webpack/src/store/blogstore.js
@@ -6,7 +6,7 @@ class BlogStore {
 
     let json = window.localStorage.getItem(LOCALSTORAGE_KEY)
     if (!json) {
-      _initData()
+      this.initData()
     } else {
       this._posts = (json && JSON.parse(json)) || []
     }


### PR DESCRIPTION
Constructor throws an exception when contents of localStorage empty.
