### PR TITLE
Include es2015-riot babel preset

### DIFF
--- a/riot_webpack/webpack.config.js
+++ b/riot_webpack/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     ],
     loaders: [
       { test: /\.css$/, include: /src/, loader: 'style!css' },
-      { test: /\.js$|\.html$/, include: /src/, loader: 'babel' },
+      { test: /\.js$|\.html$/, include: /src/, loader: 'babel', query: { presets: 'es2015-riot' } },
     ],
   },
   babel: {


### PR DESCRIPTION
I have no idea if this is a current error appearing only in windows, without this preset, webpack throws this error:

```
ERROR in ./src/index.js
Module build failed: Error: Couldn't find preset "es2015" relative to directory "feplay\riot_webpack\src"
    at feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:372:17
    at Array.map (native)
    at OptionManager.resolvePresets (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:364:20)
    at OptionManager.mergePresets (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:348:10)
    at OptionManager.mergeOptions (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:307:14)
    at OptionManager.init (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:465:10)
    at File.initOptions (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\index.js:194:75)
    at new File (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\index.js:123:22)
    at Pipeline.transform (feplay\riot_webpack\node_modules\babel-core\lib\transformation\pipeline.js:45:16)
    at transpile (feplay\riot_webpack\node_modules\babel-loader\index.js:14:22)
 @ multi app

ERROR in ./src/vendor.js
Module build failed: Error: Couldn't find preset "es2015" relative to directory "feplay\riot_webpack\src"
    at feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:372:17
    at Array.map (native)
    at OptionManager.resolvePresets (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:364:20)
    at OptionManager.mergePresets (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:348:10)
    at OptionManager.mergeOptions (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:307:14)
    at OptionManager.init (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\options\option-manager.js:465:10)
    at File.initOptions (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\index.js:194:75)
    at new File (feplay\riot_webpack\node_modules\babel-core\lib\transformation\file\index.js:123:22)
    at Pipeline.transform (feplay\riot_webpack\node_modules\babel-core\lib\transformation\pipeline.js:45:16)
    at transpile (feplay\riot_webpack\node_modules\babel-loader\index.js:14:22)
 @ multi vendor
```
